### PR TITLE
Add GeoipLiteCity.dat to code.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,4 +70,4 @@ local_settings.py
 
 \.pytest_cache/
 
-*.dat
+#*.dat


### PR DESCRIPTION
January 2, 2019 – The remaining GeoLite Legacy builds will be removed from our website. GeoLite Legacy database users will need to have switched to the GeoLite2 or commercial GeoIP databases and update their integrations.