### PR TITLE
Bulk fixes and improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,12 +73,6 @@ RUN chmod +x /usr/bin/celery-commands
 COPY src/celery-cmd /usr/bin/celery-cmd
 RUN chmod +x /usr/bin/celery-cmd
 
-# Install "geonode-contribs" apps
-RUN cd /usr/src; git clone https://github.com/GeoNode/geonode-contribs.git -b master
-# Install logstash and centralized dashboard dependencies
-RUN cd /usr/src/geonode-contribs/geonode-logstash; pip install --upgrade  -e . \
-    cd /usr/src/geonode-contribs/ldap; pip install --upgrade  -e .
-
 RUN pip install --upgrade --no-cache-dir  --src /usr/src -r requirements.txt
 RUN pip install --upgrade  -e .
 

--- a/src/geosk/api.py
+++ b/src/geosk/api.py
@@ -1,0 +1,90 @@
+import logging
+
+from django.conf import settings
+from django.utils.translation import gettext as _
+from django.forms.models import model_to_dict
+
+from tastypie.constants import ALL
+
+from geonode.groups.models import GroupProfile
+from geonode.api.resourcebase_api import LayerResource
+
+from geosk.geonode_sos import utils
+
+logger = logging.getLogger(__name__)
+
+#REST API override for layers to include additional fields required for sensors
+class SoSLayerResource(LayerResource):
+    def format_objects(self, objects):
+        """
+        Formats the object.
+        """
+        formatted_objects = []
+        for obj in objects:
+            # convert the object to a dict using the standard values.
+            # includes other values
+            values = self.VALUES + [
+                'alternate',
+                'name',
+                'resource_type'
+            ]
+            formatted_obj = model_to_dict(obj, fields=values)
+            username = obj.owner.get_username()
+            full_name = (obj.owner.get_full_name() or username)
+            formatted_obj['owner__username'] = username
+            formatted_obj['owner_name'] = full_name
+            if obj.category:
+                formatted_obj['category__gn_description'] = _(obj.category.gn_description)
+            if obj.group:
+                formatted_obj['group'] = obj.group
+                try:
+                    formatted_obj['group_name'] = GroupProfile.objects.get(slug=obj.group.name)
+                except GroupProfile.DoesNotExist:
+                    formatted_obj['group_name'] = obj.group
+
+            formatted_obj['keywords'] = [k.name for k in obj.keywords.all()] if obj.keywords else []
+            formatted_obj['regions'] = [r.name for r in obj.regions.all()] if obj.regions else []
+
+            # provide style information
+            bundle = self.build_bundle(obj=obj)
+            formatted_obj['default_style'] = self.default_style.dehydrate(
+                bundle, for_list=True)
+
+            # Add resource uri
+            formatted_obj['resource_uri'] = self.get_resource_uri(bundle)
+
+            formatted_obj['links'] = self.dehydrate_ogc_links(bundle)
+
+            if 'site_url' not in formatted_obj or len(formatted_obj['site_url']) == 0:
+                formatted_obj['site_url'] = settings.SITEURL
+
+            # Probe Remote Services
+            formatted_obj['store_type'] = 'dataset'
+            formatted_obj['online'] = True
+            if hasattr(obj, 'storeType'):
+                formatted_obj['store_type'] = obj.storeType
+                if obj.storeType == 'remoteStore' and hasattr(obj, 'remote_service'):
+                    if obj.remote_service:
+                        formatted_obj['online'] = (obj.remote_service.probe == 200)
+                    else:
+                        formatted_obj['online'] = False
+
+            formatted_obj['gtype'] = self.dehydrate_gtype(bundle)
+
+            # replace thumbnail_url with curated_thumbs
+            if hasattr(obj, 'curatedthumbnail'):
+                try:
+                    if hasattr(obj.curatedthumbnail.img_thumbnail, 'url'):
+                        formatted_obj['thumbnail_url'] = obj.curatedthumbnail.thumbnail_url
+                except Exception as e:
+                    logger.exception(e)
+
+            formatted_obj['processed'] = obj.instance_is_processed
+            
+            # Custom fields for sensors
+            formatted_obj['raw_supplemental_information'] = obj.raw_supplemental_information
+            formatted_obj['is_local_sensor'] = utils.is_local_senor(obj) if obj.resource_type == "sos_sensor" else False
+            
+            # put the object on the response stack
+            formatted_objects.append(formatted_obj)
+        return formatted_objects

--- a/src/geosk/apps.py
+++ b/src/geosk/apps.py
@@ -2,6 +2,20 @@ import os
 from django.apps import AppConfig as BaseAppConfig
 from django.conf.urls import include, url
 
+from geonode.api.urls import api as geonode_api
+from geonode.api.resourcebase_api import LayerResource
+
+class SoSLayerResource(LayerResource):
+    def format_objects(self, objects):
+        a = 1
+        return super().format_objects(objects)
+
+    def _dehydrate_links(self, bundle, link_types=None):
+        a = 1
+        super()._dehydrate_links( bundle, link_types)
+
+#geonode_api.unregister("layers")
+geonode_api.register(SoSLayerResource())
 
 def run_setup_hooks(*args, **kwargs):
     from django.conf import settings

--- a/src/geosk/geonode_sos/__init__.py
+++ b/src/geosk/geonode_sos/__init__.py
@@ -20,6 +20,6 @@ VERSION = (0, 0, 3)
 __version__ = ".".join([str(i) for i in VERSION])
 __author__ = "geosolutions-it"
 __email__ = "info@geosolutionsgroup.com"
-__url__ = "https://github.com/GeoNode/geonode-contribs/sos"
+__url__ = "https://github.com/SP7-Ritmare/starterkit/tree/upgrade_3.3.x/src/geosk/geonode_sos"
 __license__ = "GNU General Public License"
 

--- a/src/geosk/geonode_sos/sensors/views.py
+++ b/src/geosk/geonode_sos/sensors/views.py
@@ -114,8 +114,12 @@ def overwrite_harvest_resources_handle_get(request, service, handler):
     except EmptyPage:
         harvestable_resources = paginator.page(paginator.num_pages)
 
-    filter_row = [{}, {"id": 'id-filter', "data_key": "id"},
-                  {"id": 'name-filter', "data_key": "title"},]
+    filter_row = [
+        {},
+        {"id": 'id-filter', "data_key": "id"},
+        {"id": 'name-filter', "data_key": "title"},
+        {"id": 'desc-filter', "data_key": "abstract"}
+    ]
 
     _service_url = [service.service_url]*len(harvestable_resources.object_list)
 

--- a/src/geosk/geonode_sos/sos_handler.py
+++ b/src/geosk/geonode_sos/sos_handler.py
@@ -30,6 +30,7 @@ from django.utils.translation import ugettext as _
 from geonode import settings
 from geonode.base.bbox_utils import BBOXHelper
 from geonode.base.models import ExtraMetadata
+from geonode.base.models import HierarchicalKeyword
 from geonode.geoserver.security import set_geowebcache_invalidate_cache
 from geonode.layers.models import Layer
 from geonode.services.enumerations import HARVESTED
@@ -85,6 +86,8 @@ class SosServiceHandler(ServiceHandlerBase):
         self.content_response = None
         self.name = slugify(self.url)[:255]
         self.workspace = get_geoserver_cascading_workspace(create=True)
+        # Let's create the special 'local' keyword to mark local sensors
+        _ = HierarchicalKeyword.objects.get_or_create(name='local', slug='local')
 
     @property
     def parsed_service(self):
@@ -226,7 +229,7 @@ class SosServiceHandler(ServiceHandlerBase):
 
 
     def _create_layer(self, _resource_as_dict: dict, geonode_service) -> Layer:
-        _ = _resource_as_dict.pop("keywords") or []
+        keywords = _resource_as_dict.pop("keywords") or []
         geonode_layer = Layer(
             owner=geonode_service.owner,
             remote_service=geonode_service,
@@ -238,7 +241,7 @@ class SosServiceHandler(ServiceHandlerBase):
         bbox_polygon = geonode_layer.bbox_polygon
         geonode_layer.full_clean()
         geonode_layer.save(notify=True)
-        # geonode_layer.keywords.add(*keywords)
+        geonode_layer.keywords.add(*keywords)
         geonode_layer.set_default_permissions()
         # geonode_layer.extra_metadata.set()
         if bbox_polygon and srid:
@@ -260,7 +263,10 @@ class SosServiceHandler(ServiceHandlerBase):
 
         return geonode_layer
 
+    
+    
     def _from_resource_to_layer(self, _resource):
+        
         payload = {
             "name": _resource.id,
             "store": slugify(self.url)[:255],
@@ -270,8 +276,12 @@ class SosServiceHandler(ServiceHandlerBase):
             "title": _resource.title,
             "abstract": _resource.abstract,
             "srid": _resource.srs,
-            "keywords": [_resource.title]
+            "keywords": []
         }
+        local_sos_urls = [django_settings.SOS_PRIVATE_URL, django_settings.SOS_PUBLIC_URL]
+        # We mark the sensor as local with a keyword
+        if self.url and self.url in local_sos_urls:
+            payload['keywords'].append('local')
         if _resource.bbox:
             payload["bbox_polygon"] = BBOXHelper.from_xy(
                 [

--- a/src/geosk/geonode_sos/sos_handler.py
+++ b/src/geosk/geonode_sos/sos_handler.py
@@ -53,6 +53,8 @@ from geonode.thumbs.thumbnails import _generate_thumbnail_name, create_thumbnail
 from geonode.thumbs.utils import clean_bbox
 from geonode.geoserver.security import _update_geofence_rule
 
+from .utils import LOCAL_SENSOR_KEYWORD
+
 logger = logging.getLogger(__name__)
 
 
@@ -87,7 +89,7 @@ class SosServiceHandler(ServiceHandlerBase):
         self.name = slugify(self.url)[:255]
         self.workspace = get_geoserver_cascading_workspace(create=True)
         # Let's create the special 'local' keyword to mark local sensors
-        _ = HierarchicalKeyword.objects.get_or_create(name='local', slug='local')
+        _ = HierarchicalKeyword.objects.get_or_create(name=LOCAL_SENSOR_KEYWORD, slug=LOCAL_SENSOR_KEYWORD)
 
     @property
     def parsed_service(self):
@@ -281,7 +283,7 @@ class SosServiceHandler(ServiceHandlerBase):
         local_sos_urls = [django_settings.SOS_PRIVATE_URL, django_settings.SOS_PUBLIC_URL]
         # We mark the sensor as local with a keyword
         if self.url and self.url in local_sos_urls:
-            payload['keywords'].append('local')
+            payload['keywords'].append(LOCAL_SENSOR_KEYWORD)
         if _resource.bbox:
             payload["bbox_polygon"] = BBOXHelper.from_xy(
                 [

--- a/src/geosk/geonode_sos/templatetags/sos_tags.py
+++ b/src/geosk/geonode_sos/templatetags/sos_tags.py
@@ -4,6 +4,8 @@ from geonode.layers.models import Layer
 from geonode.security.utils import get_visible_resources
 from geonode.base.templatetags.base_tags import FACETS
 
+from geosk.geonode_sos import utils
+
 register = template.Library()
 
 
@@ -29,3 +31,7 @@ def get_facet_title_with_sos(value):
     elif value == 'sos_sensor':
         return "SOS Sensor"
     return value
+
+@register.simple_tag()
+def is_local_sensor(resource):
+    return utils.is_local_senor(resource)

--- a/src/geosk/geonode_sos/utils.py
+++ b/src/geosk/geonode_sos/utils.py
@@ -1,0 +1,7 @@
+from django.conf import settings
+
+LOCAL_SENSOR_KEYWORD = "local"
+
+def is_local_senor(resource):
+    found = (resource.resource_type == 'sos_sensor') and any(resource.keywords.filter(name=LOCAL_SENSOR_KEYWORD))
+    return found

--- a/src/geosk/mdtools/templates/base/resourcebase_info_panel.html
+++ b/src/geosk/mdtools/templates/base/resourcebase_info_panel.html
@@ -11,14 +11,14 @@
   {% if resource.resource_type == 'sos_sensor' %}
     <li>
       <strong>{% trans "Sensor ID" %}:</strong>
-      {{ resource.supplemental_information }}
+      <a href="{{ resource.raw_supplemental_information }}" _blank="true">{{ resource.raw_supplemental_information }}</a>
     </li>
   {% endif %}
 
   {% if resource.abstract %}
     <li>
       <strong>{% trans "Abstract" %}:</strong>
-      {{ resource.abstract|escape|urlize|linebreaks|safe }}
+      {{ resource.raw_abstract }}
     </li>
   {% endif %}
 

--- a/src/geosk/osk/api.py
+++ b/src/geosk/osk/api.py
@@ -224,6 +224,11 @@ def ediproxy_importmd(request):
         sensor.sensorml = insertsensor
         sensor.ediml = ediml
         sensor.save()
+        
+        # TODO trigger the harvesting of the new local sensot (create new harvest job for the local SOS service and run it)
+        # The procedure inside geonode.services.views.harvest_resources_handle_post must be triggered. It creates the HarvestJos
+        # then the geonode.services.tasks.harvest_resource is triggered asynchronously.
+        
         return json_response(body={'success': True, 'redirect': reverse('osk_browse')})
     else:
         return json_response(exception=sos_response.text.encode('utf8'), status=500)

--- a/src/geosk/templates/base/_resourcebase_snippet.html
+++ b/src/geosk/templates/base/_resourcebase_snippet.html
@@ -78,12 +78,12 @@
           {% if 'sos_sensor' in request.GET.values %}
           <div class="btn-toolbar">
             <div class="btn-group">
-                  <a href="{% url "osk_describe_sensor" %}?format={{ 'text/html'|urlencode }}&sensor_id={% verbatim %}{{item.supplemental_information }}{% endverbatim %}" target="_blank" data-toggle="modal" class="sensor-snippet-action-button btn btn-mini btn-primary"><span>{% trans "Sensor details" %}</span></a>
+                  <a ng-if='item.keywords.includes("local")' href="{% url "osk_describe_sensor" %}?format={{ 'text/html'|urlencode }}&sensor_id={% verbatim %}{{item.supplemental_information }}{% endverbatim %}" target="_blank" data-toggle="modal" class="sensor-snippet-action-button btn btn-mini btn-primary"><span>{% trans "Sensor details" %}</span></a>
                 {% if perms.osk.admin_sos %}
-                  <a href="{% url "osk_upload" %}?procedureId={% verbatim %}{{ item.supplemental_information }}{% endverbatim %}" class="sensor-snippet-action-button btn btn-mini  btn-success"><span>{% trans "Upload observations" %}</span></a>
+                  <a ng-if='item.keywords.includes("local")' href="{% url "osk_upload" %}?procedureId={% verbatim %}{{ item.supplemental_information }}{% endverbatim %}" class="sensor-snippet-action-button btn btn-mini  btn-success"><span>{% trans "Upload observations" %}</span></a>
                   <a href="{% verbatim %}{{ item.supplemental_information }}{% endverbatim %}" download="{% verbatim %}{{ item.supplemental_information }}{% endverbatim %}" target="_blank" data-toggle="modal" class="sensor-snippet-action-button btn btn-mini btn-success"><span>{% trans "Download SensorML" %}</span></a>
                   <a href="../observations/service?service=SOS&version=2.0.0&request=GetObservation&MergeObservationsIntoDataArray=true&procedure={% verbatim %}{{ item.supplemental_information }}{% endverbatim %}" class="sensor-snippet-action-button btn btn-mini  btn-success"><span>{% trans "Download observations" %}</span></a>
-                  <a href="{% url "osk_deletesensor" %}?procedure={% verbatim %}{{ item.supplemental_information }}{% endverbatim %}" class="sensor-snippet-action-button btn btn-mini btn-danger"><span>{% trans "Delete sensor" %}</span></a>
+                  <a ng-if='item.keywords.includes("local")' href="{% url "osk_deletesensor" %}?procedure={% verbatim %}{{ item.supplemental_information }}{% endverbatim %}" class="sensor-snippet-action-button btn btn-mini btn-danger"><span>{% trans "Delete sensor" %}</span></a>
                 {% endif %}
             </div>
         </div>

--- a/src/geosk/templates/base/_resourcebase_snippet.html
+++ b/src/geosk/templates/base/_resourcebase_snippet.html
@@ -9,7 +9,7 @@
   </div>
   <article ng-repeat="item in results" resource_id="{{ item.id }}" ng-cloak class="ng-cloak">
     {% endverbatim %}
-    <div class="col-lg-12 item-container" {% verbatim %} ng-class="{'sensor-item': item.resource_type=='sos_sensor', 'sensor-item-local' : item.keywords.includes('local')}" {% endverbatim %}>
+    <div class="col-lg-12 item-container" {% verbatim %} ng-class="{'sensor-item': item.resource_type=='sos_sensor', 'sensor-item-local' : item.is_local_sensor}" {% endverbatim %}>
     {% verbatim %}
     
       <div class="col-lg-12">
@@ -59,7 +59,7 @@
             {% endif %}
           </div>
           {% verbatim %}
-          <a ng-if='item.resource_type=="sos_sensor"' href="{{item.supplemental_information}}" style="font-size:12px;word-break:break-all;margin-bottom:5px">{{item.supplemental_information}}</a>
+          <a ng-if='item.resource_type=="sos_sensor"' href="{{item.raw_supplemental_information}}" style="font-size:12px;word-break:break-all;margin-bottom:5px">{{item.raw_supplemental_information}}</a>
           {% endverbatim %}<br>
           <em ng-if="item.store_type == 'remoteStore'">
             <span ng-if="item.online == true"><i class="fa fa-power-off text-success"></i> {% trans "Service is" %} {% trans "online" %}</span>
@@ -77,12 +77,12 @@
           <div ng-if='item.resource_type=="sos_sensor"' class="btn-toolbar">
           {% endverbatim %}
             <div class="btn-group">
-                  <a ng-if='item.keywords.includes("local")' href="{% url "osk_describe_sensor" %}?format={{ 'text/html'|urlencode }}&sensor_id={% verbatim %}{{item.supplemental_information }}{% endverbatim %}" target="_blank" data-toggle="modal" class="sensor-snippet-action-button btn btn-mini btn-primary"><span>{% trans "Sensor details" %}</span></a>
+                  <a ng-if='item.is_local_sensor' href="{% url "osk_describe_sensor" %}?format={{ 'text/html'|urlencode }}&sensor_id={% verbatim %}{{item.raw_supplemental_information }}{% endverbatim %}" target="_blank" data-toggle="modal" class="sensor-snippet-action-button btn btn-mini btn-primary"><span>{% trans "Sensor details" %}</span></a>
                 {% if perms.osk.admin_sos %}
-                  <a ng-if='item.keywords.includes("local")' href="{% url "osk_upload" %}?procedureId={% verbatim %}{{ item.supplemental_information }}{% endverbatim %}" class="sensor-snippet-action-button btn btn-mini  btn-success"><span>{% trans "Upload observations" %}</span></a>
-                  <a href="{% verbatim %}{{ item.supplemental_information }}{% endverbatim %}" download="{% verbatim %}{{ item.supplemental_information }}{% endverbatim %}" target="_blank" data-toggle="modal" class="sensor-snippet-action-button btn btn-mini btn-success"><span>{% trans "Download SensorML" %}</span></a>
-                  <a href="../observations/service?service=SOS&version=2.0.0&request=GetObservation&MergeObservationsIntoDataArray=true&procedure={% verbatim %}{{ item.supplemental_information }}{% endverbatim %}" class="sensor-snippet-action-button btn btn-mini  btn-success"><span>{% trans "Download observations" %}</span></a>
-                  <a ng-if='item.keywords.includes("local")' href="{% url "osk_deletesensor" %}?procedure={% verbatim %}{{ item.supplemental_information }}{% endverbatim %}" class="sensor-snippet-action-button btn btn-mini btn-danger"><span>{% trans "Delete sensor" %}</span></a>
+                  <a ng-if='item.is_local_sensor' href="{% url "osk_upload" %}?procedureId={% verbatim %}{{ item.raw_supplemental_information }}{% endverbatim %}" class="sensor-snippet-action-button btn btn-mini  btn-success"><span>{% trans "Upload observations" %}</span></a>
+                  <a ng-if='item.is_local_sensor' href="{% verbatim %}{{ item.raw_supplemental_information }}{% endverbatim %}" download="{% verbatim %}{{ item.raw_supplemental_information }}{% endverbatim %}" target="_blank" data-toggle="modal" class="sensor-snippet-action-button btn btn-mini btn-success"><span>{% trans "Download SensorML" %}</span></a>
+                  <a ng-if='item.is_local_sensor' href="../observations/service?service=SOS&version=2.0.0&request=GetObservation&MergeObservationsIntoDataArray=true&procedure={% verbatim %}{{ item.raw_supplemental_information }}{% endverbatim %}" class="sensor-snippet-action-button btn btn-mini  btn-success"><span>{% trans "Download observations" %}</span></a>
+                  <a ng-if='item.is_local_sensor' href="{% url "osk_deletesensor" %}?procedure={% verbatim %}{{ item.raw_supplemental_information }}{% endverbatim %}" class="sensor-snippet-action-button btn btn-mini btn-danger"><span>{% trans "Delete sensor" %}</span></a>
                 {% endif %}
             </div>
         </div>

--- a/src/geosk/templates/base/_resourcebase_snippet.html
+++ b/src/geosk/templates/base/_resourcebase_snippet.html
@@ -8,7 +8,14 @@
     {% verbatim %}
   </div>
   <article ng-repeat="item in results" resource_id="{{ item.id }}" ng-cloak class="ng-cloak">
+    {% endverbatim %}
+    {% if 'sos_sensor' in request.GET.values %}
+    <div class="col-lg-12 item-container sensor-item" {% verbatim %}ng-class="{'snsor-item-local' : item.keywords.includes('local')}"{% endverbatim %}>
+    {% else %}
     <div class="col-lg-12 item-container">
+    {% endif %}
+    {% verbatim %}
+    
       <div class="col-lg-12">
         <div class="col-lg-4 item-thumb">
           <a href="{{ item.detail_url }}">

--- a/src/geosk/templates/base/_resourcebase_snippet.html
+++ b/src/geosk/templates/base/_resourcebase_snippet.html
@@ -9,7 +9,7 @@
   </div>
   <article ng-repeat="item in results" resource_id="{{ item.id }}" ng-cloak class="ng-cloak">
     {% endverbatim %}
-    <div class="col-lg-12 item-container" {% verbatim %}ng-class="{'sensor-item': item.resource_type=='sos_sensor'}" ng-class="{'snsor-item-local' : item.keywords.includes('local')}"{% endverbatim %}>
+    <div class="col-lg-12 item-container" {% verbatim %} ng-class="{'sensor-item': item.resource_type=='sos_sensor', 'sensor-item-local' : item.keywords.includes('local')}" {% endverbatim %}>
     {% verbatim %}
     
       <div class="col-lg-12">

--- a/src/geosk/templates/base/_resourcebase_snippet.html
+++ b/src/geosk/templates/base/_resourcebase_snippet.html
@@ -9,11 +9,7 @@
   </div>
   <article ng-repeat="item in results" resource_id="{{ item.id }}" ng-cloak class="ng-cloak">
     {% endverbatim %}
-    {% if 'sos_sensor' in request.GET.values %}
-    <div class="col-lg-12 item-container sensor-item" {% verbatim %}ng-class="{'snsor-item-local' : item.keywords.includes('local')}"{% endverbatim %}>
-    {% else %}
-    <div class="col-lg-12 item-container">
-    {% endif %}
+    <div class="col-lg-12 item-container" {% verbatim %}ng-class="{'sensor-item': item.resource_type=='sos_sensor'}" ng-class="{'snsor-item-local' : item.keywords.includes('local')}"{% endverbatim %}>
     {% verbatim %}
     
       <div class="col-lg-12">
@@ -35,13 +31,13 @@
                   </span>
               </p>
               <h4>
-                  <i ng-if="item.store_type == 'remoteStore'" title="Remote Service" class="fa fa-external-link fa-1 {% endverbatim %}{% if 'sos_sensor' in request.GET.values %}sensor_icon{% endif %}{% verbatim %}" style="vertical-align:  middle;padding-right: 10px;"></i>
+                  <i ng-if="item.store_type == 'remoteStore'" title="Remote Service" class="fa fa-external-link fa-1" ng-class="{'sensor-icon': item.resource_type=='sos_sensor'}" style="vertical-align:  middle;padding-right: 10px;"></i>
                   <i ng-if="item.store_type == 'dataStore'" title="Vector Data" class="fa fa-pencil-square-o fa-1" style="vertical-align:  middle;padding-right: 10px;"></i>
                   <i ng-if="item.store_type == 'coverageStore'" title="Raster Data" class="fa fa-picture-o fa-1" style="vertical-align:  middle;padding-right: 10px;"></i>
                   <i ng-if="item.store_type == 'dataset'" title="File/Dataset" class="fa fa-newspaper-o fa-1" style="vertical-align:  middle;padding-right: 10px;"></i>
                   <i ng-if="item.store_type == 'map'" title="Map" class="fa fa-map-o fa-1" style="vertical-align:  middle;padding-right: 10px;"></i>
                   <i ng-if="item.store_type == 'geoapp'" title="App" class="fa fa-gears fa-1" style="vertical-align:  middle;padding-right: 10px;"></i>
-                  <a href="{{ item.detail_url }}" {% endverbatim %}{% if 'sos_sensor' in request.GET.values %}class="sensor_title"{% endif %}{% verbatim %}>{{ item.title }}{% endverbatim %}{% if 'sos_sensor' in request.GET.values %} sensor{% endif %}{% verbatim %}</a>
+                  <a href="{{ item.detail_url }}" ng-class="{'sensor-title': item.resource_type=='sos_sensor'}">{{ item.title }}{% endverbatim %}{% if 'sos_sensor' in request.GET.values %} sensor{% endif %}{% verbatim %}</a>
               </h4>
             </div>
             {% endverbatim %}
@@ -62,16 +58,13 @@
               {% endif %} 
             {% endif %}
           </div>
-          {% if 'sos_sensor' in request.GET.values %}
           {% verbatim %}
-          <a href="{{item.supplemental_information}}" style="font-size:12px;word-break:break-all;margin-bottom:5px">{{item.supplemental_information}}</a>
+          <a ng-if='item.resource_type=="sos_sensor"' href="{{item.supplemental_information}}" style="font-size:12px;word-break:break-all;margin-bottom:5px">{{item.supplemental_information}}</a>
           {% endverbatim %}<br>
-          {% else %}
           <em ng-if="item.store_type == 'remoteStore'">
             <span ng-if="item.online == true"><i class="fa fa-power-off text-success"></i> {% trans "Service is" %} {% trans "online" %}</span>
             <span ng-if="item.online == false"><i class="fa fa-power-off text-danger"></i> {% trans "Service is" %} {% trans "offline" %}</span>
           </em>
-          {%endif%}
           <div class="alert alert-danger" ng-if="item.dirty_state == true">{% trans "SECURITY NOT YET SYNCHRONIZED" %}
               {% verbatim %}<a href="{{ item.detail_url }}" class="btn btn-primary btn-block" data-dismiss="modal" ng-click="securityRefreshButton($event)">{% endverbatim %}{% trans "Sync permissions immediately" %}</a>
           </div>
@@ -81,9 +74,8 @@
           {% verbatim %}
           <div class="abstract" style="margin-top:5px" ng-bind-html="item.abstract | limitTo: 300"></div>
           <p class="abstract">{{ item.abstract.length  > 300 ? '...' : ''}}</p>
+          <div ng-if='item.resource_type=="sos_sensor"' class="btn-toolbar">
           {% endverbatim %}
-          {% if 'sos_sensor' in request.GET.values %}
-          <div class="btn-toolbar">
             <div class="btn-group">
                   <a ng-if='item.keywords.includes("local")' href="{% url "osk_describe_sensor" %}?format={{ 'text/html'|urlencode }}&sensor_id={% verbatim %}{{item.supplemental_information }}{% endverbatim %}" target="_blank" data-toggle="modal" class="sensor-snippet-action-button btn btn-mini btn-primary"><span>{% trans "Sensor details" %}</span></a>
                 {% if perms.osk.admin_sos %}
@@ -94,7 +86,6 @@
                 {% endif %}
             </div>
         </div>
-          {% endif %}
           {% verbatim %}
           <div class="row">
             <div class="col-lg-12 item-items">

--- a/src/geosk/templates/layers/sensor_detail.html
+++ b/src/geosk/templates/layers/sensor_detail.html
@@ -425,7 +425,7 @@
     {% endif %}
     {% if not READ_ONLY_MODE and not request.user_agent.is_mobile %}
       {% if "change_resourcebase_metadata" in perms_list or "change_resourcebase" in perms_list or "delete_resourcebase" in perms_list or "change_layer_style" in layer_perms %}
-      {% if is_local_sensor_bool %}
+      
       <li class="list-group-item">
         <button class="btn btn-primary btn-md btn-block" data-toggle="modal" data-target="#edit-layer">{% trans "Editing Tools" %}</button>
       </li>
@@ -438,15 +438,7 @@
             </div>
             <div class="modal-body">
               <div class="row edit-modal">
-                {% if "change_resourcebase_metadata" in perms_list %}
-                <div class="col-sm-3">
-                  <i class="fa fa-list-alt fa-3x"></i>
-                  <h4>{% trans "Metadata" %}</h4>
-                  <a class="btn btn-default btn-block btn-xs" href="{% url "layer_metadata" resource.service_typename %}">{% trans "Wizard" %}</a>
-                  <a class="btn btn-default btn-block btn-xs" href="{% url "layer_metadata_advanced" resource.service_typename %}">{% trans "Advanced Edit" %}</a>
-                  <a class="btn btn-default btn-block btn-xs" href="{% url "layer_metadata_upload" resource.service_typename %}">{% trans "Upload Metadata" %}</a>
-                </div>
-                {% endif %}
+                <!-- Metadata editing is hidden for sensors-->
                 {% if GEOSERVER_BASE_URL and not resource.service %}
                   {% if "change_layer_style" in layer_perms %}
                     {% if resource.storeType != "remoteStore" %}
@@ -502,7 +494,7 @@
           </div>
         </div>
       </div>
-      {% endif %}
+      
       {% endif %}
     {% endif %}
 

--- a/src/geosk/templates/layers/sensor_detail.html
+++ b/src/geosk/templates/layers/sensor_detail.html
@@ -11,6 +11,7 @@
 {% load client_lib_tags %}
 {% load proxy_lib_tags %}
 {% load layer_tags %}
+{% load sos_tags %}
 
 {% block title %}{{ resource.title|default:resource.alternate }} — {{ block.super }}{% endblock %}
 
@@ -38,6 +39,7 @@
 {% block body_class %}layers{% endblock %}
 
 {% block body_outer %}
+{% is_local_sensor resource as is_local_sensor_bool %}
 <div class="page-header">
     <style>
     #paneltbar {
@@ -47,7 +49,7 @@
 
     <h2 class="page-title">{{ resource.title|default:resource.alternate }}</h2>
     {% if resource.resource_type == 'sos_sensor' %}
-       {{ resource.supplemental_information|escape|urlize|linebreaks|safe }}
+       <a href="{{ resource.raw_supplemental_information }}" _blank="true">{{ resource.raw_supplemental_information }}</a>
     {% elif storeType == 'remoteStore' %}
     <em>
       <i class="fa fa-power-off {% if online %}text-success{% else %}text-danger{% endif %}"></i> {% trans "Service is" %} {% if online %}{% trans "online" %}{% else %}{% trans "offline" %}{% endif %} 
@@ -57,7 +59,6 @@
 
 <div class="row">
   <div class="col-md-8">
-
     <div id="embedded_map" class="mrg-btm">
       <div id="preview_map"></div>
     </div>
@@ -85,7 +86,7 @@
           {% endif %}
         {% endif %}
         {% if resource.resource_type == 'sos_sensor' %}
-          <p><a href="{{ item.supplemental_information }}"><i class="fa fa-download"></i> {% trans "Download SensorML" %}</a></p>
+          <p><a href="{{ item.raw_supplemental_information }}"><i class="fa fa-download"></i> {% trans "Download SensorML" %}</a></p>
         {% endif %}
       </article>
       {% if resource.is_mosaic %}
@@ -406,11 +407,13 @@
     {% endif %}
 
     {% if not request.user_agent.is_mobile %}  
+    {% if is_local_sensor_bool %}
     <li class="list-group-item">
       <a href="{% url "layer_metadata_detail" resource.alternate %}">
-        <button class="btn btn-primary btn-md btn-block">{% trans "Metadata Detail" %}</button>
+        <button class="btn btn-primary btn-md btn-block">{% trans "Sensor Details" %}</button>
       </a>
     </li>
+    {% endif %}
     {% endif %}
     {% display_edit_request_button resource request.user perms_list as display_request_button %}
     {% if display_request_button and not request.user_agent.is_mobile %}
@@ -422,6 +425,7 @@
     {% endif %}
     {% if not READ_ONLY_MODE and not request.user_agent.is_mobile %}
       {% if "change_resourcebase_metadata" in perms_list or "change_resourcebase" in perms_list or "delete_resourcebase" in perms_list or "change_layer_style" in layer_perms %}
+      {% if is_local_sensor_bool %}
       <li class="list-group-item">
         <button class="btn btn-primary btn-md btn-block" data-toggle="modal" data-target="#edit-layer">{% trans "Editing Tools" %}</button>
       </li>
@@ -498,6 +502,7 @@
           </div>
         </div>
       </div>
+      {% endif %}
       {% endif %}
     {% endif %}
 

--- a/src/geosk/templates/services/service_detail.html
+++ b/src/geosk/templates/services/service_detail.html
@@ -1,0 +1,142 @@
+{% extends "services/services_base.html" %}
+{% load i18n %}
+{% load guardian_tags %}
+
+{% block body %}
+<div class="twocol">
+  <h3>{{service.title|default:service.name}}</h3>
+      <p><strong>{% trans "Type" %}:</strong> {{service.service_type}}</p>
+      <p><strong>{% trans "URL" %}:</strong> {{service.base_url}}</p>
+      <p><strong>{% trans "Abstract" %}:</strong> {{service.abstract}}</p>
+      <p><strong>{% trans "Keywords" %}:</strong> {{ service.keywords.all|join:", " }}</p>
+      <p><strong>{% trans "Contact" %}:</strong> <a href="{% url "profile_detail" service.owner.username %}">{{ service.owner }}</a></p>
+
+    {% autoescape off %}
+        <h3>{% trans "Service Resources" %} <span class="badge">{{ total_resources }}</span></h3>
+        {% if total_resources == 0 %}
+            <p>{% trans "No resources have been imported yet." %}</p>
+        {% else %}
+            <div class="row">
+            <table class="table">
+                <thead>
+                <th>{% trans "Title" %}</th>
+                <th>{% trans "Description" %}</th>
+                </thead>
+                {% for job in resource_jobs %}
+                    <tr>
+                        {% if job.status != 'PROCESSED' %}
+                            <td style="width: 50%; overflow-wrap: anywhere">{{job.resource_id}}</td>
+                            <td>
+                                <div class="row">
+                                    <div class="col-md-9">
+                                        {{job.status}} - {{ job.details }}
+                                    </div>
+                                    <div class="btn-group pull-right">
+                                       {% if job.status == 'FAILED' %}
+                                        <button title="{% trans "Retry job" %}" class="btn" name="retry-{{ job.resource_id }}"><i
+                                                class="fa fa-refresh fa-fw" aria-hidden="true"></i></button>
+                                       {% endif %}
+                                    </div>
+                                </div>
+                            </td>
+                        {% else %}
+                            {% for layer in layers %}
+                                {% if layer.name == job.resource_id or layer.alternate == job.resource_id %}
+                                    <td style="width: 50%; overflow-wrap: anywhere"><a href='{{ layer.get_absolute_url }}'>{{layer.title|striptags}}</a></td>
+                                    <td>
+                                        <div class="row">
+                                            <div class="col-md-9">
+                                                {{layer.abstract|striptags}}
+                                            </div>
+                                        </div>
+                                    </td>
+                                {% endif %}
+                            {% endfor %}
+                        {% endif %}
+                    </tr>
+                {% endfor %}
+            </table>
+            </div>
+        {% endif %}
+    {% if resources.paginator.num_pages > 1 %}
+        <div class="row">
+            <nav aria-label="importable resources pages">
+                <ul class="pagination hidden-xs pull-right">
+                    {% if resources.has_previous %}
+                        <li><a id="previous" aria-label="Previous" href="?page={{ resources.previous_page_number }}">{% trans "previous" %}</a></li>
+                    {% else %}
+                        <li class="disabled"><a aria-label="Previous" href="#">{% trans "previous" %}</a></li>
+                    {% endif %}
+                    <li class="active"><a href="#">{{ resources.number }}/{{ resources.paginator.num_pages }}</a></li>
+                    {% if resources.has_next %}
+                        <li><a aria-label="{% trans "Next" %}" href="?page={{ resources.next_page_number }}">{% trans "next" %}</a></li>
+                    {% else %}
+                        <li class="disabled"><a aria-label="{% trans "Next" %}" href="#">{% trans "next" %}</a></li>
+                    {% endif %}
+                </ul>
+            </nav>
+        </div>
+    {% endif %}
+    {% endautoescape %}
+    <div class="modal fade" data-backdrop="static" data-keyboard="false" id="progressModal" tabindex="-1" role="dialog" aria-labelledby="progressModalLabel">
+        <div class="modal-dialog" role="document">
+            <div class="modal-content">
+                <div class="modal-header">
+                    {% trans "Connecting to service..." %}
+                </div>
+                <div class="modal-body">
+                    <div class="progress" id="serviceRegisterProgress">
+                        <div class="progress-bar progress-bar-striped progress-bar-info active" role="progressbar" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100" style="width: 100%;">
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+</div>
+{% endblock %}
+{% block sidebar %}
+
+    {% get_obj_perms request.user for service as "resource_perms" %}
+
+    {% if can_add_resorces or "add_resourcebase" in resource_perms or "change_resourcebase_metadata" in resource_perms or "change_service_permissions" in resource_perms %}
+    <ul class="list-group">
+        <li class="list-group-item"><h3>{% trans "Manage" %}</h3></li>
+        {% if "change_resourcebase_metadata" in resource_perms %}
+            <li class="list-group-item"><a class="btn btn-default btn-md btn-block" href="{% url "edit_service" service.id %}">{% trans "Edit Service Metadata" %}</a></li>
+        {% endif %}
+        {% if can_add_resorces %}
+            <li class="list-group-item"><a id="harvestResources" class="btn btn-default btn-md btn-block" href="{% url "harvest_resources" service.id %}">{% trans "Import Service Resources" %}</a></li>
+        {% endif %}
+        {% if "remove_service" in permissions_list or "delete_service" in permissions_list or 'delete_resourcebase' in permissions_list %}
+            <li class="list-group-item"><a class="btn btn-default btn-md btn-block" href="{% url "remove_service" service.id %}">{% trans "Remove Service" %}</a></li>
+        {% endif %}
+      </ul>
+    {% endif %}
+{% endblock %}
+{% block extra_script %}
+    {{ block.super }}
+    <script type="text/javascript">
+        $(document).ready(function () {
+            $('#harvestResources').on("click", function() {
+                $("#progressModal").modal("show");
+            });
+            $('button[name^=retry]').on('click', function () {
+                const resourceId = this.name.replace("retry-", "");
+                const retryUrl = "/services/{{ service.id }}/harvest/" + resourceId;
+                const retryForm = document.createElement('form');
+                retryForm.setAttribute("method", "post");
+                retryForm.setAttribute("action", retryUrl);
+                const csrfInputElem = document.createElement("input");
+                csrfInputElem.type = "hidden";
+                csrfInputElem.name = "csrfmiddlewaretoken";
+                csrfInputElem.value = "{{ csrf_token }}";
+                retryForm.appendChild(csrfInputElem);
+                document.body.appendChild(retryForm);
+                retryForm.submit();
+
+            });
+        });
+    </script>
+{% endblock extra_script %}

--- a/src/geosk/templates/services/service_resources_harvest.html
+++ b/src/geosk/templates/services/service_resources_harvest.html
@@ -29,9 +29,7 @@
                                 <th>{% if not errored_state %}<input type="checkbox" id="checkAll"/>{% endif %}</th>
                                 <th>{% trans "Id" %}</th>
                                 <th>{% trans "Title" %}</th>
-                                {% if not all_resources %}
                                 <th>{% trans "Abstract" %}</th>
-                                {% endif %}
                             </tr>
 
                             <tr style="background-color: lightgray">
@@ -54,6 +52,7 @@
                             </tr>
                             </thead>
                             <tbody>
+                            {% if not all_resources %}
                             {% for resource_meta in resources %}
                                 <tr>
                                     <td>
@@ -70,6 +69,22 @@
                                     {% endif %}
                                 </tr>
                             {% endfor %}
+                            {% else %}
+                            {% for resource_meta in all_resources %}
+                                <tr>
+                                    <td>
+                                        {% if not errored_state %}
+                                            <input {% if resource_meta.id in requested %}checked{% endif %}
+                                                   type="checkbox" name="resource_list"
+                                                   id="option_{{ resource_meta.id }}" value="{{ resource_meta.id }}"/>
+                                        {% endif %}
+                                    </td>
+                                    <td>{{ resource_meta.id }}</td>
+                                    <td>{{ resource_meta.title }}</td>
+                                    <td>{{ resource_meta.abstract }}</td>
+                                </tr>
+                            {% endfor %}
+                            {% endif %}
                             </tbody>
                         </table>
 

--- a/src/geosk/templates/services/service_resources_harvest.html
+++ b/src/geosk/templates/services/service_resources_harvest.html
@@ -62,7 +62,7 @@
                                                    id="option_{{ resource_meta.id }}" value="{{ resource_meta.id }}"/>
                                         {% endif %}
                                     </td>
-                                    <td>{{ resource_meta.id }}</td>
+                                    <td style="overflow-wrap: anywhere">{{ resource_meta.id }}</td>
                                     <td>{{ resource_meta.title }}</td>
                                     {% if resource_meta.abstract %}
                                     <td>{{ resource_meta.abstract }}</td>
@@ -79,7 +79,7 @@
                                                    id="option_{{ resource_meta.id }}" value="{{ resource_meta.id }}"/>
                                         {% endif %}
                                     </td>
-                                    <td>{{ resource_meta.id }}</td>
+                                    <td style="overflow-wrap: anywhere">{{ resource_meta.id }}</td>
                                     <td>{{ resource_meta.title }}</td>
                                     <td>{{ resource_meta.abstract }}</td>
                                 </tr>

--- a/src/geosk/urls.py
+++ b/src/geosk/urls.py
@@ -1,8 +1,12 @@
-from django.conf import settings
 from django.conf.urls import url, include
 from django.views.generic import TemplateView
+from django.utils.translation import gettext as _
+
 
 from geonode.urls import urlpatterns
+from geonode.api.urls import api as geonode_api
+
+
 from geosk.osk.proxy import (
     ObservationsProxy,
     SparqlProxy,
@@ -11,9 +15,14 @@ from geosk.osk.proxy import (
     NercProxy,
     MetadataProxy,
     AdamassoftProxy)
-
 from geosk.mdtools import api, views as mdtools_views
-  
+from geosk.api import SoSLayerResource
+
+# Register custom API v1 for layers to include additional fields for sensors
+geonode_api.register(SoSLayerResource())
+urlpatterns.insert(
+    0, url(r'', include(geonode_api.urls)),
+)
 
 url_already_injected = any(
     [


### PR DESCRIPTION
### CHANGELOG

- Improved layout of sensor services search and result pages
- `geonode-contribs` has been removed since it's not employed
- API v1 for layers has been overridden to have the flexibility of including custom fields inside the API response for sensors
- Formatting of the `Procedure ID` field, which is baked by the `resource.supplemental_information` field has been fixed by using the `resource.raw_supplemental_information` value, which strips HTML tags
- Local sensors can now be differentiated both inside the layers API response (`is_local_sensor` property) and with the `sos_tags.is_local_sensor` template tag. Both use `utils.is_local_sensor`. At the moment it checks the existence of a "local" keyword attached to the resource. 
- Buttons inside the sensor cards are shown only for local sensors (as agreed in the call on 16 Dec 2022)
- CSS classes added to sensor cards
- The "Metadata Details" inside the sensor detail page has been renamed to "Sensor details" and it's shown only for local sensors (as agreed in the call on 16 Dec 2022)
- Metadata editing tools have been removed from the "Edit tools" modal inside the sensor detail page (as agreed in the call on 16 Dec 2022). Metadata for sensors is managed with the EDI tools, at the moment there's no connection between this custom metadata and GeoNode's own resource metadata. 
