### PR TITLE
Parse identifiers from NERC vocabulary and removed buttons

### DIFF
--- a/src/geosk/geonode_sos/parser.py
+++ b/src/geosk/geonode_sos/parser.py
@@ -78,6 +78,7 @@ class DescribeSensorParser:
         identifiers_paths = [
             ".//sml:identifier/sml:Term[@definition='urn:ogc:def:identifier:OGC:uniqueID']//sml:value",
             ".//sml:identifier/sml:Term[@definition='urn:ogc:def:identifier:OGC:1.0:uniqueID']//sml:value",
+            ".//sml:identifier/sml:Term[@definition='http://vocab.nerc.ac.uk/collection/W07/current/IDEN0008/']//sml:value",
             ".//gml:identifier[@codeSpace='uniqueID']",
             ".//sml:identifier[@name='uniqueID']//sml:value",
         ]
@@ -89,6 +90,7 @@ class DescribeSensorParser:
         title_paths = [
             "sml:identifier[@name='short name']//sml:value",
             ".//sml:identifier/sml:Term[@definition='http://mmisw.org/ont/ioos/definition/shortName']//sml:value",
+            ".//sml:identifier/sml:Term[@definition='http://vocab.nerc.ac.uk/collection/W07/current/IDEN0006/']//sml:value",
             ".//sml:identifier[@name='Short Name']//sml:value",
             ".//sml:identifier/sml:Term[@definition='urn:ogc:def:identifier:OGC:1.0:shortname']//sml:value",
             ".//sml:identifier/sml:Term[@definition='urn:ogc:def:identifier:OGC:1.0:shortName']//sml:value",
@@ -101,6 +103,7 @@ class DescribeSensorParser:
         long_name_paths = [
             "sml:identifier[@name='long name']//sml:value",
             ".//sml:identifier/sml:Term[@definition='http://mmisw.org/ont/ioos/definition/longName']//sml:value",
+            ".//sml:identifier/sml:Term[@definition='http://vocab.nerc.ac.uk/collection/W07/current/IDEN0002/']//sml:value",
             ".//sml:identifier[@name='Long Name']//sml:value",
             ".//sml:identifier/sml:Term[@definition='urn:ogc:def:identifier:OGC:1.0:longname']//sml:value",
             ".//sml:identifier/sml:Term[@definition='urn:ogc:def:identifier:OGC:1.0:longName']//sml:value",

--- a/src/geosk/templates/base/_resourcebase_snippet.html
+++ b/src/geosk/templates/base/_resourcebase_snippet.html
@@ -77,12 +77,10 @@
           <div ng-if='item.resource_type=="sos_sensor"' class="btn-toolbar">
           {% endverbatim %}
             <div class="btn-group">
-                  <a ng-if='item.is_local_sensor' href="{% url "osk_describe_sensor" %}?format={{ 'text/html'|urlencode }}&sensor_id={% verbatim %}{{item.raw_supplemental_information }}{% endverbatim %}" target="_blank" data-toggle="modal" class="sensor-snippet-action-button btn btn-mini btn-primary"><span>{% trans "Sensor details" %}</span></a>
                 {% if perms.osk.admin_sos %}
                   <a ng-if='item.is_local_sensor' href="{% url "osk_upload" %}?procedureId={% verbatim %}{{ item.raw_supplemental_information }}{% endverbatim %}" class="sensor-snippet-action-button btn btn-mini  btn-success"><span>{% trans "Upload observations" %}</span></a>
                   <a ng-if='item.is_local_sensor' href="{% verbatim %}{{ item.raw_supplemental_information }}{% endverbatim %}" download="{% verbatim %}{{ item.raw_supplemental_information }}{% endverbatim %}" target="_blank" data-toggle="modal" class="sensor-snippet-action-button btn btn-mini btn-success"><span>{% trans "Download SensorML" %}</span></a>
                   <a ng-if='item.is_local_sensor' href="../observations/service?service=SOS&version=2.0.0&request=GetObservation&MergeObservationsIntoDataArray=true&procedure={% verbatim %}{{ item.raw_supplemental_information }}{% endverbatim %}" class="sensor-snippet-action-button btn btn-mini  btn-success"><span>{% trans "Download observations" %}</span></a>
-                  <a ng-if='item.is_local_sensor' href="{% url "osk_deletesensor" %}?procedure={% verbatim %}{{ item.raw_supplemental_information }}{% endverbatim %}" class="sensor-snippet-action-button btn btn-mini btn-danger"><span>{% trans "Delete sensor" %}</span></a>
                 {% endif %}
             </div>
         </div>

--- a/src/geosk/templates/layers/sensor_detail.html
+++ b/src/geosk/templates/layers/sensor_detail.html
@@ -407,13 +407,6 @@
     {% endif %}
 
     {% if not request.user_agent.is_mobile %}  
-    {% if is_local_sensor_bool %}
-    <li class="list-group-item">
-      <a href="{% url "layer_metadata_detail" resource.alternate %}">
-        <button class="btn btn-primary btn-md btn-block">{% trans "Sensor Details" %}</button>
-      </a>
-    </li>
-    {% endif %}
     {% endif %}
     {% display_edit_request_button resource request.user perms_list as display_request_button %}
     {% if display_request_button and not request.user_agent.is_mobile %}
@@ -480,9 +473,6 @@
                     {% if layer_type != "raster" and resource.storeType != "remoteStore" %}
                     <a class="btn btn-default btn-block btn-xs" href="{% url "new_map" %}?layer={{resource.service_typename}}&storeType={{resource.storeType}}">{% trans "Edit data" %}</a>
                     {% endif %}
-                  {% endif %}
-                  {% if "delete_resourcebase" in perms_list %}
-                  <a class="btn btn-danger btn-block btn-xs" href="{% url "layer_remove" resource.service_typename %}">{% trans "Remove" %}</a>
                   {% endif %}
                 </div>
                 {% endif %}


### PR DESCRIPTION
- The DescribeSensor returned by http://getit.lteritalia.it/observations/sos uses NERC terms for uniqueID and shortName.
- Removed "Delete" and "Sensor details" buttons for local sensors